### PR TITLE
force hdf5 file to flush

### DIFF
--- a/src/caffe/layers/hdf5_output_layer.cpp
+++ b/src/caffe/layers/hdf5_output_layer.cpp
@@ -39,6 +39,7 @@ void HDF5OutputLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
         << " to HDF5 file " << file_name_;
     hdf5_save_nd_dataset(file_id_, batch_id.str(), *bottom[i]);
   }
+  H5Fflush(file_id_, H5F_SCOPE_GLOBAL);
   current_batch_++;
 }
 


### PR DESCRIPTION
Hi, I was using the layer from this branch and found that it's better to force a flush when writing data. When the user terminates the caffe training early, this helps produce completed files.
